### PR TITLE
manifest added - include license in the tarbal

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include LICENSE
+


### PR DESCRIPTION
LICENSE file is added to the tarbal - required for PIP distribution. 